### PR TITLE
Only allow valid selector names to be created

### DIFF
--- a/admin/css/common.css
+++ b/admin/css/common.css
@@ -70,6 +70,10 @@
 	display: none;
 }
 
+.eauth-dkim-issue {
+	margin-top: 1em !important;
+}
+
 .eauth-dns-record > dt {
 	margin-top: 1em;
 	font-weight: 600;

--- a/admin/js/dkim.js
+++ b/admin/js/dkim.js
@@ -156,12 +156,16 @@ jQuery(($) => {
 			}
 		}
 
-		const res = await EmailAuthPlugin.request(eauthDkimApi.keys, 'POST', {
-			headers: {
-				'Content-Type': 'application/json',
-			},
-			body: JSON.stringify(body),
-		});
+		const res = await EmailAuthPlugin.request(
+			`${eauthDkimApi.keys}/${selector}`,
+			'POST',
+			{
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify(body) ?? '{}',
+			}
+		);
 
 		if (!res.ok) {
 			const json = await res.json();

--- a/admin/js/dkim.js
+++ b/admin/js/dkim.js
@@ -3,7 +3,7 @@
 jQuery(($) => {
 	const selectorSelect = $('[name="eauth_dkim_selector"]');
 
-	// Per RFC 6367 3.1 and RFC 5321 4.1.2
+	// Per RFC 6367 3.1 and RFC 5321 4.1.2.
 	const compliantSelectorPattern =
 		/^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/;
 
@@ -28,14 +28,18 @@ jQuery(($) => {
 				};
 			}
 		},
-		(res) =>
-			res.dns && [
-				$('<h3>').text('DNS Record'),
+		(res) => [
+			res.pass === 'partial' &&
+				$('<div>')
+					.addClass('eauth-dkim-issue')
+					.text(`${EmailAuthPlugin.EMOJIS.warning} ${res.reason}`),
+			res.dns && $('<h3>').text('DNS Record'),
+			res.dns &&
 				$('<details>').append(
 					$('<summary>').append('Show DNS Record'),
 					EmailAuthPlugin.createTxtRecord(res.host, res.dns)
 				),
-			],
+		],
 		{
 			get: (res) => ({ alignment: dkimDomain, record: res.host }),
 			type: 'DKIM Domain',
@@ -148,7 +152,7 @@ jQuery(($) => {
 
 		if (!compliantSelectorPattern.test(selector)) {
 			const ignoreNonCompliant = confirm(
-				`Selector "${selector}" is non-compliant. A valid selector must contain ASCII letters and numbers with optional hyphens in-between. Dots can be used to separate subdomains. Would you like to continue anyway?`
+				`Selector "${selector}" is non-standard. A valid selector must contain ASCII letters and numbers with optional hyphens in-between. Dots can be used to separate subdomains. Would you like to continue anyway?`
 			);
 
 			if (!ignoreNonCompliant) {

--- a/includes/api-routes.php
+++ b/includes/api-routes.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'EAUTH_API_PREFIX', 'eauth/v1' );
+define( 'EAUTH_DKIM_SELECTOR_REGEX', '[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)*' );
 
 /**
  * Check if the current user can use the admin API.
@@ -78,8 +79,8 @@ register_rest_route(
 				return dkim_create_error( 'No selector name given.' );
 			}
 
-			if ( ! preg_match( '[a-zA-Z0-9-]+', $name ) ) {
-				return dkim_create_error( 'Selectors may only contain letters, numbers and hyphens (-).' );
+			if ( ! preg_match( sprintf( '/^%s$/', EAUTH_DKIM_SELECTOR_REGEX ), $name ) ) {
+				return dkim_create_error( 'Selector does not match a valid format.' );
 			}
 
 			$keys = get_keys();
@@ -142,7 +143,7 @@ function dkim_check_ssl_error( $host, $ctx ) {
 
 register_rest_route(
 	EAUTH_API_PREFIX,
-	'/dkim/keys/(?P<name>[a-zA-Z0-9-]+)/dns/(?P<domain>[a-zA-Z0-9-.]+)',
+	sprintf( '/dkim/keys/(?P<name>%s)/dns/(?P<domain>[a-zA-Z0-9-.]+)', EAUTH_DKIM_SELECTOR_REGEX ),
 	[
 		'methods'             => 'GET',
 		'callback'            => function ( \WP_REST_Request $request ) {
@@ -187,7 +188,7 @@ register_rest_route(
 
 register_rest_route(
 	EAUTH_API_PREFIX,
-	'/dkim/keys/(?P<name>[a-zA-Z0-9-]+)/download',
+	sprintf( '/dkim/keys/(?P<name>%s)/download', EAUTH_DKIM_SELECTOR_REGEX ),
 	[
 		'methods'             => 'GET',
 		'callback'            => function ( \WP_REST_Request $request ) {
@@ -209,7 +210,7 @@ register_rest_route(
 
 register_rest_route(
 	EAUTH_API_PREFIX,
-	'/dkim/keys/(?P<name>[a-zA-Z0-9-]+)',
+	sprintf( '/dkim/keys/(?P<name>%s)', EAUTH_DKIM_SELECTOR_REGEX ),
 	[
 		'methods'             => 'DELETE',
 		'callback'            => function ( \WP_REST_Request $request ) {

--- a/includes/api-routes.php
+++ b/includes/api-routes.php
@@ -78,6 +78,10 @@ register_rest_route(
 				return dkim_create_error( 'No selector name given.' );
 			}
 
+			if ( ! preg_match("[a-zA-Z0-9-]+", $name ) ) {
+				return dkim_create_error( 'Selectors may only contain letters, numbers and hyphens (-).' );
+			}
+
 			$keys = get_keys();
 
 			if ( array_key_exists( $name, $keys ) ) {

--- a/includes/api-routes.php
+++ b/includes/api-routes.php
@@ -78,7 +78,7 @@ register_rest_route(
 				return dkim_create_error( 'No selector name given.' );
 			}
 
-			if ( ! preg_match("[a-zA-Z0-9-]+", $name ) ) {
+			if ( ! preg_match( '[a-zA-Z0-9-]+', $name ) ) {
 				return dkim_create_error( 'Selectors may only contain letters, numbers and hyphens (-).' );
 			}
 

--- a/includes/api-routes.php
+++ b/includes/api-routes.php
@@ -175,7 +175,7 @@ register_rest_route(
 					'host' => $host,
 					'dns'  => $dns,
 				],
-				check_dkim_dns( $host, $pub )
+				check_dkim_dns( $name, $domain, $pub )
 			);
 		},
 		'permission_callback' => __NAMESPACE__ . '\rest_api_permission_callback',

--- a/includes/api-routes.php
+++ b/includes/api-routes.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'EAUTH_API_PREFIX', 'eauth/v1' );
-define( 'EAUTH_DKIM_SELECTOR_REGEX', '[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)*' );
+define( 'EAUTH_DOMAIN_IN_URL_REGEX', '[a-zA-Z0-9-._]+' ); // _ is widely supported
 
 /**
  * Check if the current user can use the admin API.
@@ -68,12 +68,12 @@ function dkim_create_error( $msg, $ssl_failure = false ) {
 
 register_rest_route(
 	EAUTH_API_PREFIX,
-	'/dkim/keys',
+	sprintf( '/dkim/keys/(?P<name>%s)', EAUTH_DOMAIN_IN_URL_REGEX ),
 	[
 		'methods'             => 'POST',
 		'callback'            => function ( \WP_REST_Request $request ) {
+			$name = $request['name'];
 			$obj  = $request->get_json_params();
-			$name = $obj['name'];
 
 			if ( ! $name ) {
 				return dkim_create_error( 'No selector name given.' );
@@ -139,7 +139,7 @@ function dkim_check_ssl_error( $host, $ctx ) {
 
 register_rest_route(
 	EAUTH_API_PREFIX,
-	sprintf( '/dkim/keys/(?P<name>%s)/dns/(?P<domain>[a-zA-Z0-9-.]+)', EAUTH_DKIM_SELECTOR_REGEX ),
+	sprintf( '/dkim/keys/(?P<name>%s)/dns/(?P<domain>%s)', EAUTH_DOMAIN_IN_URL_REGEX, EAUTH_DOMAIN_IN_URL_REGEX ),
 	[
 		'methods'             => 'GET',
 		'callback'            => function ( \WP_REST_Request $request ) {
@@ -184,7 +184,7 @@ register_rest_route(
 
 register_rest_route(
 	EAUTH_API_PREFIX,
-	sprintf( '/dkim/keys/(?P<name>%s)/download', EAUTH_DKIM_SELECTOR_REGEX ),
+	sprintf( '/dkim/keys/(?P<name>%s)/download', EAUTH_DOMAIN_IN_URL_REGEX ),
 	[
 		'methods'             => 'GET',
 		'callback'            => function ( \WP_REST_Request $request ) {
@@ -206,7 +206,7 @@ register_rest_route(
 
 register_rest_route(
 	EAUTH_API_PREFIX,
-	sprintf( '/dkim/keys/(?P<name>%s)', EAUTH_DKIM_SELECTOR_REGEX ),
+	sprintf( '/dkim/keys/(?P<name>%s)', EAUTH_DOMAIN_IN_URL_REGEX ),
 	[
 		'methods'             => 'DELETE',
 		'callback'            => function ( \WP_REST_Request $request ) {
@@ -222,7 +222,7 @@ register_rest_route(
 
 register_rest_route(
 	EAUTH_API_PREFIX,
-	'/spf/check/(?P<domain>[a-zA-Z0-9-.]+)',
+	sprintf( '/spf/check/(?P<domain>%s)', EAUTH_DOMAIN_IN_URL_REGEX ),
 	[
 		'methods'             => 'GET',
 		'callback'            => function ( \WP_REST_Request $request ) {
@@ -238,7 +238,7 @@ register_rest_route(
 
 register_rest_route(
 	EAUTH_API_PREFIX,
-	'/dmarc/check/(?P<domain>[a-zA-Z0-9-.]+)',
+	sprintf( '/dmarc/check/(?P<domain>%s)', EAUTH_DOMAIN_IN_URL_REGEX ),
 	[
 		'methods'             => 'GET',
 		'callback'            => function ( \WP_REST_Request $request ) {

--- a/includes/api-routes.php
+++ b/includes/api-routes.php
@@ -79,10 +79,6 @@ register_rest_route(
 				return dkim_create_error( 'No selector name given.' );
 			}
 
-			if ( ! preg_match( sprintf( '/^%s$/', EAUTH_DKIM_SELECTOR_REGEX ), $name ) ) {
-				return dkim_create_error( 'Selector does not match a valid format.' );
-			}
-
 			$keys = get_keys();
 
 			if ( array_key_exists( $name, $keys ) ) {

--- a/includes/utils/check-dkim.php
+++ b/includes/utils/check-dkim.php
@@ -11,20 +11,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+// Per RFC 6367 3.1 and RFC 5321 4.1.2.
+define(
+	'EAUTH_DKIM_SELECTOR_REGEX',
+	'/^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/'
+);
+
 /**
  * Check if the public key is set for a domain.
  *
- * @param string   $domain The domain.
+ * @param string   $name The DKIM selector.
+ * @param string   $domain The base domain.
  * @param string   $pub The public key.
  * @param callable $txt_resolver Function to get TXT records with.
  * @return array{ pass: bool, reason: string | null }
  */
-function check_dkim_dns( $domain, $pub, $txt_resolver = null ) {
+function check_dkim_dns( $name, $domain, $pub, $txt_resolver = null ) {
 	require_once __DIR__ . '/dns-tag-value/dns-tag-value.php';
+
+	$host = "$name._domainkey.$domain";
 	$dkim = null;
 
 	try {
-		$dkim = DNSTagValue\get_map( $domain, null, $txt_resolver );
+		$dkim = DNSTagValue\get_map( $host, null, $txt_resolver );
 	} catch ( DNSTagValue\Exception $e ) {
 		return [
 			'pass'   => false,
@@ -43,6 +52,13 @@ function check_dkim_dns( $domain, $pub, $txt_resolver = null ) {
 		return [
 			'pass'   => false,
 			'reason' => 'Public key is incorrect.',
+		];
+	}
+
+	if ( ! preg_match( EAUTH_DKIM_SELECTOR_REGEX, $name ) ) {
+		return [
+			'pass'   => 'partial',
+			'reason' => 'Selector name is non-standard.',
 		];
 	}
 

--- a/tests/unit/CheckDkimTest.php
+++ b/tests/unit/CheckDkimTest.php
@@ -34,21 +34,34 @@ class CheckDkimTest extends TestCase {
 
 	public function testNormal() {
 		$resolve = $this->makeTxtResolver( 'test._domainkey.domain.test', [ 'txt' => 'p=PUBLIC_KEY' ] );
-		$res     = check_dkim_dns( 'test._domainkey.domain.test', 'PUBLIC_KEY', $resolve );
+		$res     = check_dkim_dns( 'test', 'domain.test', 'PUBLIC_KEY', $resolve );
 
 		$this->assertEquals( [ 'pass' => true ], $res );
 	}
 
 	public function testEntries() {
 		$resolve = $this->makeTxtResolver( 'test._domainkey.domain.test', [ 'entries' => [ 'v=DKIM1; p=PUBLIC', '_KEY' ] ] );
-		$res     = check_dkim_dns( 'test._domainkey.domain.test', 'PUBLIC_KEY', $resolve );
+		$res     = check_dkim_dns( 'test', 'domain.test', 'PUBLIC_KEY', $resolve );
 
 		$this->assertEquals( [ 'pass' => true ], $res );
 	}
 
+	public function testNonStandard() {
+		$resolve = $this->makeTxtResolver( 'te_st._domainkey.domain.test', [ 'txt' => 'v=DKIM1; p=PUBLIC_KEY' ] );
+		$res     = check_dkim_dns( 'te_st', 'domain.test', 'PUBLIC_KEY', $resolve );
+
+		$this->assertEquals(
+			[
+				'pass'   => 'partial',
+				'reason' => 'Selector name is non-standard.',
+			],
+			$res
+		);
+	}
+
 	public function testMissingKey() {
 		$resolve = $this->makeTxtResolver( 'test._domainkey.domain.test', [ 'txt' => 'v=DKIM1; a=b;' ] );
-		$res     = check_dkim_dns( 'test._domainkey.domain.test', 'PUBLIC_KEY', $resolve );
+		$res     = check_dkim_dns( 'test', 'domain.test', 'PUBLIC_KEY', $resolve );
 
 		$this->assertEquals(
 			[
@@ -61,7 +74,7 @@ class CheckDkimTest extends TestCase {
 
 	public function testIncorrectKey() {
 		$resolve = $this->makeTxtResolver( 'test._domainkey.domain.test', [ 'txt' => 'v=DKIM1; p=PRIVATE_KEY' ] );
-		$res     = check_dkim_dns( 'test._domainkey.domain.test', 'PUBLIC_KEY', $resolve );
+		$res     = check_dkim_dns( 'test', 'domain.test', 'PUBLIC_KEY', $resolve );
 
 		$this->assertEquals(
 			[
@@ -74,7 +87,7 @@ class CheckDkimTest extends TestCase {
 
 	public function testMultipleRecords() {
 		$resolve = $this->makeTxtResolver( 'test._domainkey.domain.test', [ 'txt' => 'v=DKIM1; p=PUBLIC_KEY' ], [ 'txt' => 'v=DKIM1; p=PUBLIC_KEY' ] );
-		$res     = check_dkim_dns( 'test._domainkey.domain.test', 'PUBLIC_KEY', $resolve );
+		$res     = check_dkim_dns( 'test', 'domain.test', 'PUBLIC_KEY', $resolve );
 
 		$this->assertEquals(
 			[
@@ -87,7 +100,7 @@ class CheckDkimTest extends TestCase {
 
 	public function testNoRecord() {
 		$resolve = $this->makeTxtResolver( 'test._domainkey.domain.test' );
-		$res     = check_dkim_dns( 'test._domainkey.domain.test', 'PUBLIC_KEY', $resolve );
+		$res     = check_dkim_dns( 'test', 'domain.test', 'PUBLIC_KEY', $resolve );
 
 		$this->assertEquals(
 			[


### PR DESCRIPTION
Fixes #2

As described in the issue, DKIM selectors containing periods could be created but not used, downloaded or deleted.

The cause of the problem was that the API routes are only configured to work for valid selector paths (only letters, numbers and hyphens), but for the POST request creating a new key, no such check was present, which made creation of invalid selectors possible but prevented any further actions with the resulting key.

This PR adds a check to the key creation so that only valid selector names can be created.